### PR TITLE
Add big deprecation notice and instructions on how to switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,20 @@
 
 See [this issue](https://github.com/purescript/package-sets/issues/270) for context.
 
-If you wish to switch to the new upstream and you're using [spago](https://github.com/spacchetti/spago),
-you can just run:
+### Switching with `spago`
+
+If you wish to switch to the new upstream you can just run:
 
 ```bash
 $ spago package-set-upgrade
 ```
 (note: this will update to the latest published package-set)
+
+### Switching with `psc-package`
+
+You `psc-package.json` should change in the following way:
+- the `source` key would change from `https://github.com/spacchetti/spacchetti.git` to `https://github.com/purescript/package-sets.git`
+- the `set` would need to be pointed to a release of the new repo, e.g. at the time of writing that is "psc-0.12.3-20190227"
 
 <hr>
 <hr>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
+# DEPRECATION NOTICE
+
+## This repo has been merged into [`purescript/package-sets`](https://github.com/purescript/package-sets)
+
+See [this issue](https://github.com/purescript/package-sets/issues/270) for context.
+
+If you wish to switch to the new upstream and you're using [spago](https://github.com/spacchetti/spago),
+you can just run:
+
+```bash
+$ spago package-set-upgrade
+```
+(note: this will update to the latest published package-set)
+
+<hr>
+<hr>
+<hr>
+
+
 # Spacchetti
 
 [![Build Status](https://travis-ci.org/spacchetti/spacchetti.svg?branch=master)](https://travis-ci.org/spacchetti/spacchetti)


### PR DESCRIPTION
Note: this will need to wait until a new version of spago with support for the new package-set is released.